### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,12 +48,10 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
     compile 'org.roboguice:roboguice:2.0'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'org.eclipse.mylyn.github:org.eclipse.egit.github.core:4.1.0.201509280440-r'
-    compile 'com.android.support:support-v4:23.0.1'
     compile('com.google.inject.extensions:guice-assistedinject:3.0') {
         exclude group: 'com.google.inject'
     }


### PR DESCRIPTION
Seems like okhttp and support-v4 are duplicated,  (see the ones in *), removing dups

01:08:40: Executing external task 'dependencies'...
Could not find ZipAlign task. Did you specify a signingConfig for the variation Release?
:app:dependencies

Project :app

compile - Classpath for compiling the main sources.
+--- com.android.support:appcompat-v7:23.0.1
|    \--- com.android.support:support-v4:23.0.1
|         \--- com.android.support:support-annotations:23.0.1
+--- com.squareup.picasso:picasso:2.5.2
+--- com.squareup.okhttp:okhttp:2.5.0
|    \--- com.squareup.okio:okio:1.6.0
+--- com.squareup.okhttp:okhttp-urlconnection:2.5.0
|    \--- com.squareup.okhttp:okhttp:2.5.0 (*)
+--- org.roboguice:roboguice:2.0
|    \--- com.google.inject:guice:3.0
|         +--- javax.inject:javax.inject:1
|         +--- aopalliance:aopalliance:1.0
|         \--- org.sonatype.sisu.inject:cglib:2.2.1-v20090111
|              \--- asm:asm:3.1
+--- com.google.code.gson:gson:2.4
+--- org.eclipse.mylyn.github:org.eclipse.egit.github.core:4.1.0.201509280440-r
+--- com.android.support:support-v4:23.0.1 (*)
+--- com.google.inject.extensions:guice-assistedinject:3.0
+--- com.viewpagerindicator:library:2.4.1
\--- :lib:
