### PR TITLE
Version from git tag instead of hardcoded

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,16 @@ if (file('credentials.config').exists() ) {
     apply from: 'credentials.config';
 }
 
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.1'
@@ -14,7 +24,8 @@ android {
         minSdkVersion 8
         targetSdkVersion 22
         versionCode 2100
-        versionName '1.1.0'
+        versionName = getVersionName()
+
     }
 
     packagingOptions {

--- a/app/src/main/java/com/github/mobile/accounts/LoginActivity.java
+++ b/app/src/main/java/com/github/mobile/accounts/LoginActivity.java
@@ -40,6 +40,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
@@ -246,6 +247,19 @@ public class LoginActivity extends RoboActionBarAccountAuthenticatorActivity {
         loginText.setAdapter(new ArrayAdapter<String>(this,
                 android.R.layout.simple_dropdown_item_1line,
                 getEmailAddresses()));
+
+
+	String versionName;
+	try {
+	    versionName = getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+	} catch (PackageManager.NameNotFoundException exc) {
+	    versionName = null;
+	}
+
+	TextView version = (TextView) findViewById(R.id.app_version);
+	version.setText(versionName);
+
+
     }
 
     @Override

--- a/app/src/main/res/layout/login.xml
+++ b/app/src/main/res/layout/login.xml
@@ -91,4 +91,11 @@
         </LinearLayout>
     </ScrollView>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:id="@+id/app_version"
+        android:layout_gravity="center_horizontal" />
+
 </LinearLayout>


### PR DESCRIPTION
The version string displayed in the app should ideally be derived from the git tag (git describe --tag), and not defined statically in duplicate in the gradle config as a string. This pull request implements the above and includes a proof-of-concept for displaying the version on the LoginActivity View. Developers will further benefit from seeing a dynamically generated version that reflects the git commit id from which the build originates.

Note: When the app is built from sources that have a git tag consistent with other release tags (i.e. "ForkHub-v1.1.0") the value of versionName will evaluate to the string representation of the tag.
