### PR TITLE
Fix repository icon padding

### DIFF
--- a/app/src/main/res/layout/repo_item.xml
+++ b/app/src/main/res/layout/repo_item.xml
@@ -14,13 +14,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/ListItem"
-    android:gravity="center_vertical"
-    android:paddingBottom="0dp"
-    android:paddingLeft="0dp"
-    android:paddingRight="0dp"
-    android:paddingTop="0dp" >
+<RelativeLayout style="@style/ListItem"
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                android:gravity="center_vertical"
+                android:paddingBottom="0dp"
+                android:paddingLeft="0dp"
+                android:paddingRight="0dp"
+                android:paddingTop="0dp">
 
     <LinearLayout
         android:id="@+id/ll_header"
@@ -30,19 +30,19 @@
         android:layout_alignParentTop="true"
         android:background="@color/background"
         android:orientation="vertical"
-        android:paddingTop="10dp" >
+        android:paddingTop="10dp">
 
         <TextView
             android:id="@+id/tv_header"
             style="@style/ListSubtitleText"
             android:paddingBottom="5dp"
             android:paddingLeft="10dp"
-            android:textColor="@color/text_recent" />
+            android:textColor="@color/text_recent"/>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/text_recent" />
+            android:background="@color/text_recent"/>
     </LinearLayout>
 
     <TextView
@@ -50,8 +50,8 @@
         style="@style/PrimaryIcon"
         android:layout_alignParentLeft="true"
         android:layout_below="@id/ll_header"
-        android:layout_marginLeft="5dp"
-        android:layout_marginTop="10dp" />
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="10dp"/>
 
     <LinearLayout
         android:id="@+id/ll_details"
@@ -63,9 +63,9 @@
         android:paddingBottom="5dp"
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
-        android:paddingTop="10dp" >
+        android:paddingTop="10dp">
 
-        <include layout="@layout/repo_details" />
+        <include layout="@layout/repo_details"/>
     </LinearLayout>
 
     <View
@@ -75,6 +75,6 @@
         android:layout_alignParentLeft="true"
         android:layout_below="@id/ll_details"
         android:layout_marginTop="5dp"
-        android:background="@drawable/list_divider" />
+        android:background="@drawable/list_divider"/>
 
 </RelativeLayout>


### PR DESCRIPTION
This changes the left padding on `tv_repo_icon` to be `10dp` instead of `5dp`.

Notice the padding discrepancy in the images:
<img src="https://cloud.githubusercontent.com/assets/1526881/15899963/9ebd2f9e-2d6b-11e6-81eb-3161c113f132.png" width="250"> <img src="https://cloud.githubusercontent.com/assets/1526881/15899964/a075d3b8-2d6b-11e6-867b-c042b9a0d51b.png" width="250">

Looks like Android Studio automatically cleaned up some of the XML formatting in the layout as well.