### PR TITLE
Improved Intent to Launch Playstore to rate the aplication

### DIFF
--- a/app/src/main/java/com/github/mobile/core/repo/StarForkHubTask.java
+++ b/app/src/main/java/com/github/mobile/core/repo/StarForkHubTask.java
@@ -16,6 +16,7 @@
 package com.github.mobile.core.repo;
 
 import android.accounts.Account;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -134,7 +135,12 @@ public class StarForkHubTask extends AuthenticatedUserTask<Integer> implements D
             new StarRepositoryTask(context, repository).start();
             break;
         case NUMBER_EXECUTIONS_NEEDED_PLAY_STORE:
-            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=jp.forkhub")));
+            try {
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=jp.forkhub")));
+            } catch (ActivityNotFoundException e) {
+                Log.d(TAG, "PlayStore not installed, using other browser", e);
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=jp.forkhub")));
+            }
             break;
         }
     }


### PR DESCRIPTION
When User is Propmt to Rate the Application on Playstore, the Application will launch the Playstore directly instead of letting user to choose browsers (including playstore) to open the link.
If Playstore is not installed on the device then, user can choose any browser to open google play 