### PR TITLE
Change Holo dialogs to Material

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/LightAlertDialog.java
+++ b/app/src/main/java/com/github/mobile/ui/LightAlertDialog.java
@@ -17,9 +17,14 @@ package com.github.mobile.ui;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.os.Build;
+
+import static android.R.style.Theme;
+import static android.R.style.Theme_Holo_Light_Dialog;
+import static android.R.style.Theme_Material_Light_Dialog_Alert;
 
 /**
- * Alert dialog using the Holo Light theme
+ * Alert dialog using the Material Light theme
  */
 public class LightAlertDialog extends AlertDialog {
 
@@ -30,7 +35,10 @@ public class LightAlertDialog extends AlertDialog {
      * @return dialog
      */
     public static AlertDialog create(final Context context) {
-        return new LightAlertDialog(context, THEME_HOLO_LIGHT);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            return new LightAlertDialog(context, Theme_Material_Light_Dialog_Alert);
+        else
+            return new LightAlertDialog(context, Theme_Holo_Light_Dialog);
     }
 
     private LightAlertDialog(final Context context, final int theme) {
@@ -42,7 +50,7 @@ public class LightAlertDialog extends AlertDialog {
     }
 
     /**
-     * Alert dialog builder using the Holo Light theme
+     * Alert dialog builder using the Material Light theme
      */
     public static class Builder extends AlertDialog.Builder {
 
@@ -53,7 +61,10 @@ public class LightAlertDialog extends AlertDialog {
          * @return dialog builder
          */
         public static LightAlertDialog.Builder create(final Context context) {
-            return new LightAlertDialog.Builder(context, THEME_HOLO_LIGHT);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+                return new LightAlertDialog(context, Theme_Material_Light_Dialog_Alert);
+            else
+                return new LightAlertDialog(context, Theme_Holo_Light_Dialog);
         }
 
         private Builder(Context context) {

--- a/app/src/main/java/com/github/mobile/ui/LightProgressDialog.java
+++ b/app/src/main/java/com/github/mobile/ui/LightProgressDialog.java
@@ -18,12 +18,15 @@ package com.github.mobile.ui;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.os.Build;
 
 import com.github.mobile.R;
 
+import static android.R.style.Theme_Holo_Light_Dialog;
+import static android.R.style.Theme_Material_Light_Dialog_Alert;
 
 /**
- * Progress dialog in Holo Light theme
+ * Progress dialog in Material Light theme
  */
 public class LightProgressDialog extends ProgressDialog {
 
@@ -55,6 +58,6 @@ public class LightProgressDialog extends ProgressDialog {
     }
 
     private LightProgressDialog(Context context, CharSequence message) {
-        super(context, THEME_HOLO_LIGHT);
+        super(context, Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? Theme_Material_Light_Dialog_Alert : Theme_Holo_Light_Dialog);
     }
 }


### PR DESCRIPTION
This change allows Material dialogs to be used if available (running Lollipop or above), while maintaining support for API < 21. `THEME_HOLO_LIGHT` is also apparently deprecated, so it has been replaced.