### PR TITLE
Password should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/login.xml
+++ b/app/src/main/res/layout/login.xml
@@ -77,6 +77,7 @@
                     android:hint="@string/password"
                     android:imeOptions="actionDone"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:typeface="monospace" />
 
             </android.support.design.widget.TextInputLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.